### PR TITLE
feat: Implement BRC20 predeploy functionality

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -15,8 +15,8 @@ use {
     metrics::Metrics,
     okx::{
       brc20::entry::{
-        BRC20BalanceValue, BRC20LowerCaseTickerValue, BRC20ReceiptsValue, BRC20TickerInfoValue,
-        BRC20TransferAssetValue,
+        BRC20BalanceValue, BRC20LowerCaseTickerValue, BRC20PredeployValue, BRC20ReceiptsValue,
+        BRC20TickerInfoValue, BRC20TransferAssetValue,
       },
       entry::{AddressTickerKeyValue, InscriptionReceiptsValue},
     },
@@ -96,6 +96,7 @@ define_table! { BTC_DOMAIN_TO_SEQUENCE_NUMBER, &str, u32}
 
 // BRC-20 tables
 define_table! { BRC20_BALANCES, &AddressTickerKeyValue, &BRC20BalanceValue }
+define_table! { BRC20_PREDEPLOYS, &str, &BRC20PredeployValue }
 define_table! { BRC20_TICKER_ENTRY, &BRC20LowerCaseTickerValue, &BRC20TickerInfoValue }
 define_table! { BRC20_TRANSACTION_ID_TO_RECEIPTS, &TxidValue, &BRC20ReceiptsValue }
 define_table! { BRC20_SATPOINT_TO_TRANSFER_ASSETS, &SatPointValue, &BRC20TransferAssetValue }

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -450,6 +450,7 @@ impl Updater<'_> {
     // BRC20 tables
     let mut brc20_ticker_info = wtx.open_table(BRC20_TICKER_ENTRY)?;
     let mut brc20_balances = wtx.open_table(BRC20_BALANCES)?;
+    let mut brc20_predeploys = wtx.open_table(BRC20_PREDEPLOYS)?;
     let mut brc20_receipts = wtx.open_table(BRC20_TRANSACTION_ID_TO_RECEIPTS)?;
     let mut brc20_satpoint_to_transfer_assets =
       wtx.open_table(BRC20_SATPOINT_TO_TRANSFER_ASSETS)?;
@@ -753,6 +754,7 @@ impl Updater<'_> {
       let mut context = TableContext::new(
         &mut inscription_receipts,
         &mut brc20_balances,
+        &mut brc20_predeploys,
         &mut brc20_ticker_info,
         &mut brc20_receipts,
         &mut brc20_satpoint_to_transfer_assets,

--- a/src/okx/brc20.rs
+++ b/src/okx/brc20.rs
@@ -1,6 +1,6 @@
 use super::{entry::DynamicEntry, *};
-use crate::index::Curse;
 use crate::Chain;
+use crate::{index::Curse, okx::brc20::operation::Predeploy};
 use fixed_point::FixedPoint;
 use once_cell::sync::Lazy;
 use operation::{BRC20OperationExtractor, Deploy, Mint, RawOperation, Transfer};
@@ -25,9 +25,15 @@ pub(crate) use self::{
   ticker::{BRC20LowerCaseTicker, BRC20Ticker},
 };
 const SELF_ISSUANCE_TICKER_LENGTH: usize = 5;
+const PREDEPLOYED_TICKER_LENGTH: usize = 6;
+
 #[derive(Debug, Clone)]
 pub enum BRC20Operation {
-  Deploy(Deploy),
+  Predeploy(Predeploy),
+  Deploy {
+    deploy: Deploy,
+    parent: Option<InscriptionId>,
+  },
   Mint {
     op: Mint,
     parent: Option<InscriptionId>,
@@ -108,6 +114,17 @@ impl BRC20CreationOperationExtractor for CreatedInscription<'_> {
       self.pre_jubilant_curse_reason,
     ) {
       match self.inscription.extract_brc20_operation() {
+        Ok(RawOperation::Predeploy(predeploy)) => {
+          if height < HardForks::predeploy_activation_height(&chain) {
+            log::debug!(
+              "Pre-deploy feature is not activated at height: {} for inscription: {}",
+              height,
+              self.inscription_id
+            );
+            return None;
+          }
+          Some(BRC20Operation::Predeploy(predeploy))
+        }
         Ok(RawOperation::Deploy(mut deploy)) => {
           // Filter out invalid deployments with a 5-byte ticker.
           // proposal for issuance self mint token.
@@ -132,7 +149,21 @@ impl BRC20CreationOperationExtractor for CreatedInscription<'_> {
           } else {
             deploy.self_mint = None;
           }
-          Some(BRC20Operation::Deploy(deploy))
+          if deploy.tick.len() == PREDEPLOYED_TICKER_LENGTH {
+            if height < HardForks::six_byte_deploy_activation_height(&chain) {
+              log::debug!(
+                "Pre-deployed 6-byte tickers are not activated at height: {} for inscription: {} with ticker length: {}",
+                height,
+                self.inscription_id,
+                PREDEPLOYED_TICKER_LENGTH
+              );
+              return None;
+            }
+          }
+          Some(BRC20Operation::Deploy {
+            deploy,
+            parent: self.parents.first().cloned(),
+          })
         }
         Ok(RawOperation::Mint(mint)) => Some(BRC20Operation::Mint {
           op: mint,

--- a/src/okx/brc20.rs
+++ b/src/okx/brc20.rs
@@ -146,10 +146,7 @@ impl BRC20CreationOperationExtractor for CreatedInscription<'_> {
               );
               return None;
             }
-          } else {
-            deploy.self_mint = None;
-          }
-          if deploy.tick.len() == PREDEPLOYED_TICKER_LENGTH {
+          } else if deploy.tick.len() == PREDEPLOYED_TICKER_LENGTH {
             if height < HardForks::six_byte_deploy_activation_height(&chain) {
               log::debug!(
                 "Pre-deployed 6-byte tickers are not activated at height: {} for inscription: {} with ticker length: {}",
@@ -159,6 +156,8 @@ impl BRC20CreationOperationExtractor for CreatedInscription<'_> {
               );
               return None;
             }
+          } else {
+            deploy.self_mint = None;
           }
           Some(BRC20Operation::Deploy {
             deploy,

--- a/src/okx/brc20/entry.rs
+++ b/src/okx/brc20/entry.rs
@@ -26,6 +26,15 @@ impl_bincode_dynamic_entry!(BRC20Ticker, BRC20TickerValue);
 pub type BRC20LowerCaseTickerValue = [u8];
 impl_bincode_dynamic_entry!(BRC20LowerCaseTicker, BRC20LowerCaseTickerValue);
 
+pub type BRC20PredeployValue = [u8];
+impl_bincode_dynamic_entry!(BRC20Predeploy, BRC20PredeployValue);
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BRC20Predeploy {
+  pub hash: [u8; 32],
+  pub predeployer: UtxoAddress,
+  pub block_height: u32,
+}
+
 pub(crate) type BRC20TickerInfoValue = [u8];
 impl_bincode_dynamic_entry!(BRC20TickerInfo, BRC20TickerInfoValue);
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -104,6 +113,22 @@ mod tests {
       lower_ticker,
       BRC20Ticker::from_str("abcd").unwrap().to_lowercase()
     );
+  }
+
+  #[test]
+  fn test_predeploy_store_load() {
+    let predeploy = BRC20Predeploy {
+      hash: [1u8; 32],
+      predeployer: UtxoAddress::from_str(
+        "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+        bitcoin::Network::Bitcoin,
+      )
+      .unwrap(),
+      block_height: 100,
+    };
+    let value = predeploy.store();
+    let loaded_predeploy = BRC20Predeploy::load(&value);
+    assert_eq!(predeploy, loaded_predeploy);
   }
 
   #[test]

--- a/src/okx/brc20/error.rs
+++ b/src/okx/brc20/error.rs
@@ -36,6 +36,21 @@ pub enum BRC20Error {
   #[error("Self-mint operation denied: insufficient permissions")]
   SelfMintPermissionDenied,
 
+  #[error("Salt not found for ticker: {0}")]
+  SaltNotFound(String),
+
+  #[error("Salt is an invalid hex string for ticker: {0}")]
+  SaltInvalidHex(String),
+
+  #[error("Predeploy not found for ticker: {0}")]
+  PredeployNotFound(String),
+
+  #[error("Predeploy too young for ticker: {0}, block height: {1}")]
+  PredeployTooYoung(String, u32),
+
+  #[error("Predeploy hash invalid for ticker: {0}")]
+  PredeployHashInvalid(String),
+
   #[error("Numeric error occurred: {0}")]
   NumericError(#[from] fixed_point::NumParseError),
 }

--- a/src/okx/brc20/event.rs
+++ b/src/okx/brc20/event.rs
@@ -3,6 +3,7 @@ use super::*;
 #[derive(Debug, Clone, Copy, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum BRC20OpType {
+  Predeploy,
   Deploy,
   Mint,
   InscribeTransfer,
@@ -12,7 +13,8 @@ pub enum BRC20OpType {
 impl From<&BRC20Operation> for BRC20OpType {
   fn from(value: &BRC20Operation) -> Self {
     match value {
-      BRC20Operation::Deploy(_) => BRC20OpType::Deploy,
+      BRC20Operation::Predeploy(_) => BRC20OpType::Predeploy,
+      BRC20Operation::Deploy { .. } => BRC20OpType::Deploy,
       BRC20Operation::Mint { .. } => BRC20OpType::Mint,
       BRC20Operation::InscribeTransfer(_) => BRC20OpType::InscribeTransfer,
       BRC20Operation::Transfer { .. } => BRC20OpType::Transfer,
@@ -22,10 +24,18 @@ impl From<&BRC20Operation> for BRC20OpType {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub enum BRC20Event {
+  Predeploy(PredeployEvent),
   Deploy(DeployEvent),
   Mint(MintEvent),
   InscribeTransfer(InscribeTransferEvent),
   Transfer(TransferEvent),
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct PredeployEvent {
+  pub hash: [u8; 32],
+  pub predeployer: UtxoAddress,
+  pub block_height: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]

--- a/src/okx/brc20/executor.rs
+++ b/src/okx/brc20/executor.rs
@@ -8,6 +8,7 @@ use super::{
 mod deploy;
 mod inscribe_transfer;
 mod mint;
+mod predeploy;
 mod transfer;
 
 /// Represents a message used for executing BRC20 operations.
@@ -72,7 +73,8 @@ impl BRC20ExecutionMessage {
     blocktime: u32,
   ) -> Result<BRC20Receipt> {
     let result = match &self.operation {
-      BRC20Operation::Deploy(..) => self.execute_deploy(context, height, blocktime),
+      BRC20Operation::Predeploy(_) => self.execute_predeploy(context, height),
+      BRC20Operation::Deploy { .. } => self.execute_deploy(context, height, blocktime),
       BRC20Operation::Mint { .. } => self.execute_mint(context, height),
       BRC20Operation::InscribeTransfer(_) => self.execute_inscribe_transfer(context),
       BRC20Operation::Transfer { .. } => self.execute_transfer(context),

--- a/src/okx/brc20/executor/deploy.rs
+++ b/src/okx/brc20/executor/deploy.rs
@@ -1,5 +1,11 @@
+use bitcoin::hashes::sha256;
+
+use crate::okx::brc20::entry::BRC20Predeploy;
+
 use super::*;
 use std::u128;
+
+const MINIMUM_PREDEPLOY_AGE: u32 = 3;
 
 impl BRC20ExecutionMessage {
   pub(super) fn execute_deploy(
@@ -8,7 +14,7 @@ impl BRC20ExecutionMessage {
     height: u32,
     blocktime: u32,
   ) -> Result<BRC20Receipt, ExecutionError> {
-    let BRC20Operation::Deploy(deploy) = &self.operation else {
+    let BRC20Operation::Deploy { deploy, parent } = &self.operation else {
       unreachable!()
     };
 
@@ -21,6 +27,23 @@ impl BRC20ExecutionMessage {
       return Err(ExecutionError::ExecutionFailed(
         BRC20Error::DuplicateDeployment(ticker.to_string()),
       ));
+    }
+
+    // validate the predeploy if the ticker length is 6
+    if ticker.len() == PREDEPLOYED_TICKER_LENGTH {
+      let Some(parent) = parent else {
+        return Err(ExecutionError::ExecutionFailed(
+          BRC20Error::PredeployNotFound(ticker.to_string()),
+        ));
+      };
+      // check if the ticker is predeployed properly
+      let Some(predeploy) = context.load_brc20_predeploy(&parent)? else {
+        return Err(ExecutionError::ExecutionFailed(
+          BRC20Error::PredeployNotFound(ticker.to_string()),
+        ));
+      };
+
+      validate_predeploy_hash(&predeploy, &deploy, &ticker, height)?;
     }
 
     // validate and parse the decimals.
@@ -114,5 +137,158 @@ impl BRC20ExecutionMessage {
         max_mint_limit,
       })),
     })
+  }
+}
+
+fn validate_predeploy_hash(
+  predeploy: &BRC20Predeploy,
+  deploy: &Deploy,
+  ticker: &BRC20Ticker,
+  height: u32,
+) -> Result<(), ExecutionError> {
+  if predeploy.block_height.saturating_add(MINIMUM_PREDEPLOY_AGE) > height {
+    return Err(ExecutionError::ExecutionFailed(
+      BRC20Error::PredeployTooYoung(ticker.to_string(), predeploy.block_height),
+    ));
+  }
+
+  let Some(salt) = &deploy.salt else {
+    return Err(ExecutionError::ExecutionFailed(BRC20Error::SaltNotFound(
+      ticker.to_string(),
+    )));
+  };
+
+  let Ok(salt_bytes) = hex::decode(salt) else {
+    return Err(ExecutionError::ExecutionFailed(BRC20Error::SaltInvalidHex(
+      salt.clone(),
+    )));
+  };
+
+  let salted_ticker = [
+    ticker.as_bytes(),
+    &salt_bytes,
+    &predeploy.predeployer.to_script_bytes(),
+  ]
+  .concat();
+
+  if sha256::Hash::from_slice(&predeploy.hash)
+    != Ok(sha256::Hash::hash(
+      sha256::Hash::hash(&salted_ticker)
+        .to_byte_array()
+        .as_slice(),
+    ))
+  {
+    return Err(ExecutionError::ExecutionFailed(
+      BRC20Error::PredeployHashInvalid(ticker.to_string()),
+    ));
+  }
+
+  Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_validate_predeploy_hash_ok() {
+    let predeploy = BRC20Predeploy {
+      hash: sha256::Hash::from_str(
+        "4245293d3aa93d79f79554f0bee7565d7da6f19f4025b26c9d0440dba9eade10",
+      )
+      .unwrap()
+      .as_byte_array()
+      .as_slice()
+      .try_into()
+      .unwrap(),
+      predeployer: UtxoAddress::from_str(
+        "bc1qhqexvv8f4rqgwyk8yl60xrgn75ams53v4a5pm9",
+        Network::Bitcoin,
+      )
+      .unwrap(),
+      block_height: 100,
+    };
+
+    let deploy = Deploy {
+      tick: "EXAMPL".to_string(),
+      max_supply: "1000000".to_string(),
+      decimals: Some("2".to_string()),
+      self_mint: Some(false),
+      mint_limit: Some("500000".to_string()),
+      salt: Some(hex::encode("okxsalt".as_bytes())),
+    };
+
+    let ticker = BRC20Ticker::from_str("EXAMPL").unwrap();
+
+    let result = validate_predeploy_hash(&predeploy, &deploy, &ticker, 104);
+    assert!(result.is_ok());
+  }
+
+  #[test]
+  fn test_validate_predeploy_hash_too_soon() {
+    let predeploy = BRC20Predeploy {
+      hash: sha256::Hash::from_str(
+        "4245293d3aa93d79f79554f0bee7565d7da6f19f4025b26c9d0440dba9eade10",
+      )
+      .unwrap()
+      .as_byte_array()
+      .as_slice()
+      .try_into()
+      .unwrap(),
+      predeployer: UtxoAddress::from_str(
+        "bc1qhqexvv8f4rqgwyk8yl60xrgn75ams53v4a5pm9",
+        Network::Bitcoin,
+      )
+      .unwrap(),
+      block_height: 100,
+    };
+
+    let deploy = Deploy {
+      tick: "EXAMPL".to_string(),
+      max_supply: "1000000".to_string(),
+      decimals: Some("2".to_string()),
+      self_mint: Some(false),
+      mint_limit: Some("500000".to_string()),
+      salt: Some(hex::encode("okxsalt".as_bytes())),
+    };
+
+    let ticker = BRC20Ticker::from_str("EXAMPL").unwrap();
+
+    let result = validate_predeploy_hash(&predeploy, &deploy, &ticker, 102);
+    assert!(result.is_err());
+  }
+
+  #[test]
+  fn test_validate_predeploy_hash_err() {
+    let predeploy = BRC20Predeploy {
+      hash: sha256::Hash::from_str(
+        "3a6eb0794f5f5e8e2c3f4b5a6d7e8f90123456789abcdef0123456789abcdef0",
+      )
+      .unwrap()
+      .as_byte_array()
+      .as_slice()
+      .try_into()
+      .unwrap(),
+      predeployer: UtxoAddress::from_str(
+        "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+        Network::Bitcoin,
+      )
+      .unwrap(),
+      block_height: 100,
+    };
+
+    let deploy = Deploy {
+      tick: "EXAMPL".to_string(),
+      max_supply: "1000000".to_string(),
+      decimals: Some("2".to_string()),
+      self_mint: Some(false),
+      mint_limit: Some("500000".to_string()),
+      salt: Some("abcdef1234567890".to_string()),
+    };
+
+    let ticker = BRC20Ticker::from_str("EXAMPL").unwrap();
+
+    let result = validate_predeploy_hash(&predeploy, &deploy, &ticker, 104);
+    assert!(result.is_err());
   }
 }

--- a/src/okx/brc20/executor/predeploy.rs
+++ b/src/okx/brc20/executor/predeploy.rs
@@ -1,0 +1,45 @@
+use crate::okx::{
+  brc20::{
+    entry::BRC20Predeploy,
+    event::{BRC20Event, BRC20OpType, PredeployEvent},
+    executor::ExecutionError,
+    BRC20ExecutionMessage, BRC20Operation, BRC20Receipt,
+  },
+  context::TableContext,
+};
+
+impl BRC20ExecutionMessage {
+  pub(super) fn execute_predeploy(
+    &self,
+    context: &mut TableContext,
+    height: u32,
+  ) -> Result<BRC20Receipt, ExecutionError> {
+    let BRC20Operation::Predeploy(predeploy) = &self.operation else {
+      unreachable!()
+    };
+
+    // Insert the new predeploy record.
+    let predeploy_record = BRC20Predeploy {
+      hash: predeploy.hash,
+      predeployer: self.receiver.clone().unwrap(),
+      block_height: height,
+    };
+    context.insert_brc20_predeploy(&self.inscription_id, predeploy_record)?;
+
+    Ok(BRC20Receipt {
+      inscription_id: self.inscription_id,
+      sequence_number: self.sequence_number,
+      inscription_number: self.inscription_number,
+      old_satpoint: self.old_satpoint,
+      new_satpoint: self.new_satpoint,
+      sender: self.sender.clone(),
+      receiver: self.receiver.clone().unwrap(),
+      op_type: BRC20OpType::Predeploy,
+      result: Ok(BRC20Event::Predeploy(PredeployEvent {
+        hash: predeploy.hash,
+        predeployer: self.receiver.clone().unwrap(),
+        block_height: height,
+      })),
+    })
+  }
+}

--- a/src/okx/brc20/operation.rs
+++ b/src/okx/brc20/operation.rs
@@ -3,9 +3,10 @@ use serde_json::{json, Value};
 
 mod deploy;
 mod mint;
+mod predeploy;
 mod transfer;
 
-pub use self::{deploy::Deploy, mint::Mint, transfer::Transfer};
+pub use self::{deploy::Deploy, mint::Mint, predeploy::Predeploy, transfer::Transfer};
 
 pub const PROTOCOL_LITERAL: &str = "brc-20";
 
@@ -16,6 +17,8 @@ pub trait BRC20OperationExtractor {
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(tag = "op")]
 pub enum RawOperation {
+  #[serde(rename = "predeploy")]
+  Predeploy(Predeploy),
   #[serde(rename = "deploy")]
   Deploy(Deploy),
   #[serde(rename = "mint")]
@@ -87,6 +90,36 @@ mod tests {
   use super::*;
 
   #[test]
+  fn test_predeploy_deserialize() {
+    let hash = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+    let decoded_hash = hex::decode(hash).unwrap().as_slice().try_into().unwrap();
+    let json_str = format!(
+      r##"{{
+      "p": "brc-20",
+      "op": "predeploy",
+      "hash": "{hash}"
+    }}"##
+    );
+    assert_eq!(
+      deserialize_brc20_operation(&json_str).unwrap(),
+      RawOperation::Predeploy(Predeploy { hash: decoded_hash })
+    );
+  }
+
+  #[test]
+  fn test_predeploy_deserialize_invalid_hash() {
+    let hash = "invalidhash";
+    let json_str = format!(
+      r##"{{
+      "p": "brc-20",
+      "op": "predeploy",
+      "hash": "{hash}"
+    }}"##
+    );
+    assert!(deserialize_brc20_operation(&json_str).is_err());
+  }
+
+  #[test]
   fn test_deploy_deserialize() {
     let max_supply = "21000000".to_string();
     let mint_limit = "1000".to_string();
@@ -109,6 +142,7 @@ mod tests {
         mint_limit: Some(mint_limit),
         decimals: None,
         self_mint: None,
+        salt: None,
       })
     );
   }
@@ -161,7 +195,7 @@ mod tests {
   fn test_json_duplicate_field() {
     let json_str = r#"{"p":"brc-20","op":"mint","tick":"smol","amt":"333","amt":"33"}"#;
     assert_eq!(
-      deserialize_brc20_operation(json_str).unwrap(),
+      deserialize_brc20_operation(&json_str).unwrap(),
       RawOperation::Mint(Mint {
         tick: String::from("smol"),
         amount: String::from("33"),
@@ -172,7 +206,8 @@ mod tests {
   #[test]
   fn test_missing_required_key() {
     assert_eq!(
-      deserialize_brc20_operation(r#"{"p":"brc-20","op":"transfer","tick":"abcd"}"#).unwrap_err(),
+      deserialize_brc20_operation(r#"{"p":"brc-20","op":"transfer","tick":"abcd"}"#)
+        .unwrap_err(),
       Error::ParseOperationJsonError("missing field `amt`".to_string())
     );
   }
@@ -180,7 +215,7 @@ mod tests {
   #[test]
   fn test_json_non_string() {
     let json_str = r#"{"p":"brc-20","op":"mint","tick":"smol","amt":33}"#;
-    assert!(deserialize_brc20_operation(json_str).is_err())
+    assert!(deserialize_brc20_operation(&json_str).is_err())
   }
 
   #[test]
@@ -208,19 +243,20 @@ mod tests {
   fn test_duplicate_key() {
     let json_str = r#"{"p":"brc-20","op":"deploy","tick":"smol","max":"100","lim":"10","dec":"17","max":"200","lim":"20","max":"300"}"#;
     assert_eq!(
-      deserialize_brc20_operation(json_str).unwrap(),
+      deserialize_brc20_operation(&json_str).unwrap(),
       RawOperation::Deploy(Deploy {
         tick: "smol".to_string(),
         max_supply: "300".to_string(),
         mint_limit: Some("20".to_string()),
         decimals: Some("17".to_string()),
         self_mint: None,
+        salt: None,
       })
     );
 
     let json_str = r#"{"p":"brc-20","op":"mint","tick":"smol","amt":"100","tick":"hhaa","amt":"200","tick":"actt"}"#;
     assert_eq!(
-      deserialize_brc20_operation(json_str).unwrap(),
+      deserialize_brc20_operation(&json_str).unwrap(),
       RawOperation::Mint(Mint {
         tick: "actt".to_string(),
         amount: "200".to_string(),
@@ -229,7 +265,7 @@ mod tests {
 
     let json_str = r#"{"p":"brc-20","op":"transfer","tick":"smol","amt":"100","tick":"hhaa","amt":"200","tick":"actt"}"#;
     assert_eq!(
-      deserialize_brc20_operation(json_str).unwrap(),
+      deserialize_brc20_operation(&json_str).unwrap(),
       RawOperation::Transfer(Transfer {
         tick: "actt".to_string(),
         amount: "200".to_string(),

--- a/src/okx/brc20/operation/deploy.rs
+++ b/src/okx/brc20/operation/deploy.rs
@@ -12,6 +12,8 @@ pub struct Deploy {
   pub decimals: Option<String>,
   #[serde(default, with = "parse_bool", skip_serializing_if = "Option::is_none")]
   pub self_mint: Option<bool>,
+  #[serde(rename = "salt", default, skip_serializing_if = "Option::is_none")]
+  pub salt: Option<String>,
 }
 
 mod parse_bool {
@@ -53,6 +55,7 @@ mod tests {
       mint_limit: Some("12".to_string()),
       decimals: Some("11".to_string()),
       self_mint: None,
+      salt: None,
     };
 
     assert_eq!(
@@ -78,6 +81,7 @@ mod tests {
         mint_limit: Some("12".to_string()),
         decimals: Some("11".to_string()),
         self_mint: None,
+        salt: None,
       }
     );
   }
@@ -90,6 +94,7 @@ mod tests {
       mint_limit: Some("12".to_string()),
       decimals: Some("11".to_string()),
       self_mint: None,
+      salt: None,
     };
 
     assert_eq!(
@@ -148,6 +153,7 @@ mod tests {
         mint_limit: Some("10".to_string()),
         decimals: Some("10".to_string()),
         self_mint: Some(true),
+        salt: None,
       }
     );
 
@@ -160,6 +166,7 @@ mod tests {
         mint_limit: Some("10".to_string()),
         decimals: Some("10".to_string()),
         self_mint: Some(true),
+        salt: None,
       }
     );
 
@@ -172,6 +179,7 @@ mod tests {
         mint_limit: Some("10".to_string()),
         decimals: Some("10".to_string()),
         self_mint: Some(false),
+        salt: None,
       }
     );
   }
@@ -227,6 +235,7 @@ mod tests {
         mint_limit: None,
         decimals: Some("10".to_string()),
         self_mint: None,
+        salt: None,
       }
     );
 
@@ -239,6 +248,7 @@ mod tests {
         mint_limit: Some("10".to_string()),
         decimals: None,
         self_mint: None,
+        salt: None,
       }
     );
 
@@ -251,7 +261,40 @@ mod tests {
         mint_limit: None,
         decimals: None,
         self_mint: None,
+        salt: None,
       }
+    );
+  }
+
+  #[test]
+  fn test_with_salt() {
+    let obj = Deploy {
+      tick: "abcd".to_string(),
+      max_supply: "12000".to_string(),
+      mint_limit: Some("12".to_string()),
+      decimals: Some("11".to_string()),
+      self_mint: None,
+      salt: Some("random_salt".to_string()),
+    };
+
+    assert_eq!(
+      serde_json::to_string(&obj).unwrap(),
+      format!(
+        r##"{{"tick":"{}","max":"{}","lim":"{}","dec":"{}","salt":"{}"}}"##,
+        obj.tick,
+        obj.max_supply,
+        obj.mint_limit.as_ref().unwrap(),
+        obj.decimals.as_ref().unwrap(),
+        obj.salt.as_ref().unwrap()
+      )
+    );
+
+    assert_eq!(
+      serde_json::from_str::<Deploy>(
+        r#"{"tick":"abcd","max":"12000","lim":"12","dec":"11","salt":"random_salt"}"#
+      )
+      .unwrap(),
+      obj
     );
   }
 }

--- a/src/okx/brc20/operation/predeploy.rs
+++ b/src/okx/brc20/operation/predeploy.rs
@@ -1,0 +1,77 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+pub struct Predeploy {
+  #[serde(rename = "hash", with = "parse_sha256")]
+  pub hash: [u8; 32],
+}
+
+mod parse_sha256 {
+  use serde::{de, Deserialize, Deserializer, Serializer};
+
+  pub fn serialize<S>(v: &[u8; 32], serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    serializer.serialize_str(&hex::encode(v))
+  }
+
+  pub fn deserialize<'de, D>(deserializer: D) -> Result<[u8; 32], D::Error>
+  where
+    D: Deserializer<'de>,
+  {
+    let s: String = Deserialize::deserialize(deserializer)?;
+    let bytes = hex::decode(s).map_err(|_| de::Error::custom("invalid hex string"))?;
+    if bytes.len() != 32 {
+      return Err(de::Error::custom("invalid length for hash"));
+    }
+    let mut array = [0u8; 32];
+    array.copy_from_slice(&bytes);
+    Ok(array)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_serialize() {
+    let obj = Predeploy {
+      hash: [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+        26, 27, 28, 29, 30, 31, 32,
+      ],
+    };
+    assert_eq!(
+      serde_json::to_string(&obj).unwrap(),
+      r#"{"hash":"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"}"#
+    );
+  }
+
+  #[test]
+  fn test_deserialize() {
+    assert_eq!(
+      serde_json::from_str::<Predeploy>(
+        r#"{"hash":"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"}"#
+      )
+      .unwrap(),
+      Predeploy {
+        hash: [
+          1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+          25, 26, 27, 28, 29, 30, 31, 32
+        ],
+      }
+    );
+  }
+
+  #[test]
+  fn test_deserialize_invalid_hex_string() {
+    assert!(serde_json::from_str::<Predeploy>(r#"{"hash":"abcdeflol"}"#).is_err());
+  }
+
+  #[test]
+  fn test_deserialize_invalid_length() {
+    assert!(serde_json::from_str::<Predeploy>(r#"{"hash":"abcdef"}"#).is_err());
+  }
+}

--- a/src/okx/brc20/policies.rs
+++ b/src/okx/brc20/policies.rs
@@ -16,6 +16,26 @@ impl HardForks {
     }
   }
 
+  /// Proposed block activation height for pre-deploy feature.
+  /// It is 10 blocks earlier than the 6-byte deployment activation height to allow users
+  /// to pre-deploy their desired tickers before the actual deployment.
+  /// Proposal content: https://github.com/bestinslot-xyz/brc20-proposals/tree/main/001-6-byte-namespace/index.md
+  pub fn predeploy_activation_height(chain: &Chain) -> u32 {
+    Self::six_byte_deploy_activation_height(chain) - 10
+  }
+
+  /// Proposed block activation height for 6-byte deployment feature.
+  /// Proposal content: https://github.com/bestinslot-xyz/brc20-proposals/tree/main/001-6-byte-namespace/index.md
+  pub fn six_byte_deploy_activation_height(chain: &Chain) -> u32 {
+    match chain {
+      Chain::Mainnet => 912690, // decided by community
+      Chain::Testnet => 0,
+      Chain::Regtest => 0,
+      Chain::Signet => 230000,
+      Chain::Testnet4 => 0,
+    }
+  }
+
   pub fn draft_reinscription_activation_height(chain: &Chain) -> u32 {
     match chain {
       Chain::Mainnet => u32::MAX, // todo: not set yet

--- a/src/okx/brc20/ticker.rs
+++ b/src/okx/brc20/ticker.rs
@@ -5,7 +5,7 @@ pub struct BRC20Ticker(Box<[u8]>);
 
 impl BRC20Ticker {
   pub const MIN_SIZE: usize = 4;
-  pub const MAX_SIZE: usize = 5;
+  pub const MAX_SIZE: usize = 6;
 
   pub fn len(&self) -> usize {
     self.0.len()
@@ -14,6 +14,10 @@ impl BRC20Ticker {
   pub fn to_lowercase(&self) -> BRC20LowerCaseTicker {
     let str = self.to_string().to_lowercase();
     BRC20LowerCaseTicker(str.as_bytes().to_vec().into_boxed_slice())
+  }
+
+  pub fn as_bytes(&self) -> &[u8] {
+    &self.0
   }
 }
 
@@ -30,13 +34,26 @@ impl FromStr for BRC20Ticker {
     let bytes = s.as_bytes();
     let length = bytes.len();
 
-    // BRC20Ticker names on the Bitcoin mainnet will be limited to 4 - 5 bytes.
+    // BRC20Ticker names on the Bitcoin mainnet will be limited to 4 - 6 bytes.
     if !(Self::MIN_SIZE..=Self::MAX_SIZE).contains(&length) {
       return Err(Error::Range);
     }
 
+    if length == PREDEPLOYED_TICKER_LENGTH {
+      if !is_valid_predeployed_ticker(s) {
+        return Err(Error::InvalidCharacters);
+      }
+    }
+
     Ok(Self(bytes.into()))
   }
+}
+
+fn is_valid_predeployed_ticker(ticker: &str) -> bool {
+  // Allow only ASCII alphanumeric characters and hyphens in 6-byte
+  ticker
+    .chars()
+    .all(|c| c.is_ascii_alphanumeric() || c == '-')
 }
 
 #[derive(Debug, PartialEq, Clone, PartialOrd, Ord, Eq, SerializeDisplay, Deserialize)]
@@ -57,12 +74,14 @@ impl Display for BRC20LowerCaseTicker {
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 pub enum Error {
   Range,
+  InvalidCharacters,
 }
 
 impl Display for Error {
   fn fmt(&self, f: &mut Formatter) -> fmt::Result {
     match self {
       Self::Range => write!(f, "ticker name out of range"),
+      Self::InvalidCharacters => write!(f, "ticker name contains invalid characters"),
     }
   }
 }
@@ -74,9 +93,32 @@ mod tests {
   use super::*;
 
   #[test]
+  fn test_six_bytes_ticker_valid() {
+    assert!(BRC20Ticker::from_str("ABCD-E").is_ok());
+    assert!(BRC20Ticker::from_str("1234-5").is_ok());
+    assert!(BRC20Ticker::from_str("A1B2-C").is_ok());
+  }
+
+  #[test]
+  fn test_six_bytes_ticker_invalid() {
+    assert_eq!(
+      BRC20Ticker::from_str("ABCD@E"),
+      Err(Error::InvalidCharacters)
+    );
+    assert_eq!(
+      BRC20Ticker::from_str("1234_5"),
+      Err(Error::InvalidCharacters)
+    );
+    assert_eq!(
+      BRC20Ticker::from_str("A1B2 C"),
+      Err(Error::InvalidCharacters)
+    );
+  }
+
+  #[test]
   fn test_ticker_from_str_valid_bytes() {
     assert!(BRC20Ticker::from_str("BTC").is_err()); // length is less than MIN_SIZE
-    assert!(BRC20Ticker::from_str("BITOIN").is_err()); // length is greater than MAX_SIZE
+    assert!(BRC20Ticker::from_str("BITCOIN").is_err()); // length is greater than MAX_SIZE
 
     assert_eq!(BRC20Ticker::from_str("ORDI").unwrap().to_string(), "ORDI"); // length is 4 bytes
     assert_eq!(BRC20Ticker::from_str("USDTS").unwrap().to_string(), "USDTS"); // length is 5 bytes
@@ -85,7 +127,7 @@ mod tests {
   #[test]
   fn test_ticker_from_str_invalid_bytes() {
     assert_eq!(BRC20Ticker::from_str(""), Err(Error::Range));
-    assert_eq!(BRC20Ticker::from_str("XAİİ"), Err(Error::Range));
+    assert_eq!(BRC20Ticker::from_str("XAİİa"), Err(Error::Range));
   }
 
   #[test]
@@ -109,8 +151,8 @@ mod tests {
   fn test_ticker_from_str_invalid() {
     assert_eq!(BRC20Ticker::from_str(""), Err(Error::Range));
     assert_eq!(BRC20Ticker::from_str("BTC"), Err(Error::Range));
-    assert_eq!(BRC20Ticker::from_str("BITCOI"), Err(Error::Range));
-    assert_eq!(BRC20Ticker::from_str("XAİİ"), Err(Error::Range));
+    assert_eq!(BRC20Ticker::from_str("BITCOIN"), Err(Error::Range));
+    assert_eq!(BRC20Ticker::from_str("XAİİa"), Err(Error::Range));
   }
 
   #[test]
@@ -208,7 +250,7 @@ mod tests {
 
   #[test]
   fn test_error_display() {
-    let ticker1 = BRC20Ticker::from_str("BTCDDD");
+    let ticker1 = BRC20Ticker::from_str("BTCDDDD");
     assert_eq!(
       format!("{}", ticker1.err().unwrap()),
       "ticker name out of range"
@@ -279,7 +321,7 @@ mod tests {
 
     // deserialize with error
     assert_eq!(
-      bincode::deserialize::<BRC20Ticker>(&[6, 0, 0, 0, 0, 0, 0, 0, 65, 98, 49, 59, 47, 49])
+      bincode::deserialize::<BRC20Ticker>(&[7, 0, 0, 0, 0, 0, 0, 0, 65, 98, 49, 59, 57, 47, 49])
         .unwrap_err()
         .to_string(),
       Error::Range.to_string()

--- a/src/okx/context.rs
+++ b/src/okx/context.rs
@@ -1,8 +1,9 @@
 use super::{
   brc20::{
     entry::{
-      BRC20Balance, BRC20BalanceValue, BRC20Receipt, BRC20ReceiptsValue, BRC20TickerInfo,
-      BRC20TickerInfoValue, BRC20TransferAsset, BRC20TransferAssetValue,
+      BRC20Balance, BRC20BalanceValue, BRC20Predeploy, BRC20PredeployValue, BRC20Receipt,
+      BRC20ReceiptsValue, BRC20TickerInfo, BRC20TickerInfoValue, BRC20TransferAsset,
+      BRC20TransferAssetValue,
     },
     BRC20Ticker,
   },
@@ -20,6 +21,8 @@ pub(crate) struct TableContext<'a, 'txn> {
   inscription_receipts: &'a mut Table<'txn, &'static TxidValue, &'static InscriptionReceiptsValue>,
   // BRC20 tables
   brc20_balances: &'a mut Table<'txn, &'static AddressTickerKeyValue, &'static BRC20BalanceValue>,
+  // Inscription ID as str -> BRC20 Predeploy Hash, Deployer Address and Block Height
+  brc20_predeploys: &'a mut Table<'txn, &'static str, &'static BRC20PredeployValue>,
   brc20_ticker_info:
     &'a mut Table<'txn, &'static AddressTickerKeyValue, &'static BRC20TickerInfoValue>,
   brc20_receipts: &'a mut Table<'txn, &'static TxidValue, &'static BRC20ReceiptsValue>,
@@ -40,6 +43,7 @@ impl<'a, 'txn> TableContext<'a, 'txn> {
       &'static InscriptionReceiptsValue,
     >,
     brc20_balances: &'a mut Table<'txn, &'static AddressTickerKeyValue, &'static BRC20BalanceValue>,
+    brc20_predeploys: &'a mut Table<'txn, &'static str, &'static BRC20PredeployValue>,
     brc20_ticker_info: &'a mut Table<
       'txn,
       &'static AddressTickerKeyValue,
@@ -63,6 +67,7 @@ impl<'a, 'txn> TableContext<'a, 'txn> {
     Self {
       inscription_receipts,
       brc20_balances,
+      brc20_predeploys,
       brc20_ticker_info,
       brc20_receipts,
       brc20_satpoint_to_transfer_assets,
@@ -71,6 +76,30 @@ impl<'a, 'txn> TableContext<'a, 'txn> {
       bitmap_block_height_to_sequence_number,
       btc_domain_to_sequence_number,
     }
+  }
+
+  pub fn insert_brc20_predeploy(
+    &mut self,
+    inscription_id: &InscriptionId,
+    predeploy: BRC20Predeploy,
+  ) -> Result<(), redb::StorageError> {
+    self.brc20_predeploys.insert(
+      inscription_id.to_string().as_str(),
+      predeploy.store().as_ref(),
+    )?;
+    Ok(())
+  }
+
+  pub fn load_brc20_predeploy(
+    &mut self,
+    inscription_id: &InscriptionId,
+  ) -> Result<Option<BRC20Predeploy>, redb::StorageError> {
+    Ok(
+      self
+        .brc20_predeploys
+        .get(inscription_id.to_string().as_str())?
+        .map(|v| DynamicEntry::load(v.value())),
+    )
   }
 
   pub fn load_brc20_ticker_info(

--- a/src/okx/utxo_address.rs
+++ b/src/okx/utxo_address.rs
@@ -32,6 +32,18 @@ impl UtxoAddress {
     )
   }
 
+  pub fn to_script_bytes(&self) -> Vec<u8> {
+    match &self.0 {
+      UtxoAddressInner::Address(address) => address
+        .clone()
+        .assume_checked()
+        .script_pubkey()
+        .as_bytes()
+        .to_vec(),
+      UtxoAddressInner::ScriptHash { script_hash, .. } => script_hash.as_byte_array().to_vec(),
+    }
+  }
+
   pub fn from_str(address: &str, network: Network) -> Result<Self> {
     Ok(
       Address::from_str(address)?

--- a/src/subcommand/server/okx/brc20/receipt.rs
+++ b/src/subcommand/server/okx/brc20/receipt.rs
@@ -8,6 +8,7 @@ use crate::okx::brc20::{
 #[serde(untagged)]
 #[serde(rename_all = "camelCase")]
 pub enum ApiTxEvent {
+  PredeployEvent(ApiPredeployEvent),
   Deploy(ApiDeployEvent),
   Mint(ApiMintEvent),
   InscribeTransfer(ApiInscribeTransferEvent),
@@ -18,6 +19,18 @@ pub enum ApiTxEvent {
 impl From<BRC20Receipt> for ApiTxEvent {
   fn from(event: BRC20Receipt) -> Self {
     match event.result {
+      Ok(BRC20Event::Predeploy(predeploy_event)) => Self::PredeployEvent(ApiPredeployEvent {
+        inscription_id: event.inscription_id,
+        inscription_number: event.inscription_number,
+        old_satpoint: event.old_satpoint,
+        new_satpoint: event.new_satpoint,
+        from: event.sender.into(),
+        to: event.receiver.into(),
+        valid: true,
+        hash: hex::encode(predeploy_event.hash),
+        msg: "ok".to_string(),
+        event: event.op_type,
+      }),
       Ok(BRC20Event::Deploy(deploy_event)) => Self::Deploy(ApiDeployEvent {
         inscription_id: event.inscription_id,
         inscription_number: event.inscription_number,
@@ -101,6 +114,22 @@ pub struct ApiErrorEvent {
   pub new_satpoint: SatPoint,
   pub from: ApiUtxoAddress,
   pub to: ApiUtxoAddress,
+  pub valid: bool,
+  pub msg: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiPredeployEvent {
+  #[serde(rename = "type")]
+  pub event: BRC20OpType,
+  pub inscription_id: InscriptionId,
+  pub inscription_number: i32,
+  pub old_satpoint: SatPoint,
+  pub new_satpoint: SatPoint,
+  pub from: ApiUtxoAddress,
+  pub to: ApiUtxoAddress,
+  pub hash: String,
   pub valid: bool,
   pub msg: String,
 }
@@ -308,6 +337,49 @@ mod tests {
   use super::*;
   #[test]
   fn test_serialize_api_event() {
+    let predeploy: ApiPredeployEvent = ApiPredeployEvent {
+      event: BRC20OpType::Predeploy,
+      inscription_id: Default::default(),
+      inscription_number: 0,
+      old_satpoint: Default::default(),
+      new_satpoint: Default::default(),
+      from: UtxoAddress::from_str(
+        "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+        Network::Bitcoin,
+      )
+      .unwrap()
+      .into(),
+      to: UtxoAddress::from_str(
+        "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+        Network::Bitcoin,
+      )
+      .unwrap()
+      .into(),
+      hash: "abcdef".to_string(),
+      valid: true,
+      msg: "ok".to_string(),
+    };
+
+    assert_eq!(
+      serde_json::to_string_pretty(&predeploy).unwrap(),
+      r#"{
+  "type": "predeploy",
+  "inscriptionId": "0000000000000000000000000000000000000000000000000000000000000000i0",
+  "inscriptionNumber": 0,
+  "oldSatpoint": "0000000000000000000000000000000000000000000000000000000000000000:4294967295:0",
+  "newSatpoint": "0000000000000000000000000000000000000000000000000000000000000000:4294967295:0",
+  "from": {
+    "address": "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
+  },
+  "to": {
+    "address": "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
+  },
+  "hash": "abcdef",
+  "valid": true,
+  "msg": "ok"
+}"#
+    );
+
     let deploy = ApiDeployEvent {
       event: BRC20OpType::Deploy,
       tick: BRC20Ticker::from_str("ordi").unwrap(),


### PR DESCRIPTION
- Added support for BRC20 predeploy operations, including new data structures and serialization logic.
- Introduced `BRC20Predeploy` struct to store predeploy information such as hash, predeployer address, and block height.
- Updated `BRC20Operation` enum to include `Predeploy` variant.
- Enhanced `TableContext` to manage predeploy records in the database.
- Implemented validation logic for predeploy operations, ensuring correct hash and age checks.
- Updated ticker validation to support 6-byte tickers for predeploys.
- Added tests for predeploy serialization, validation, and integration with existing BRC20 operations.
- Modified API event structures to include predeploy events for external communication.