### PR TITLE
Fix invalid parents

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -6933,4 +6933,87 @@ mod tests {
     // zero
     assert_eq!(Statistic::Schema.key(), 0);
   }
+
+  #[test]
+  fn same_tx_forward_parent_reference_does_not_panic() {
+    for context in Context::configurations() {
+      context.mine_blocks(2);
+
+      // Get the coinbase transactions from block 1 and block 2
+      let coinbase1 = context.core.tx(1, 0);
+      let coinbase2 = context.core.tx(2, 0);
+
+      let coinbase1_txid = coinbase1.compute_txid();
+      let coinbase2_txid = coinbase2.compute_txid();
+
+      // Pre-compute the txid of the transaction we're about to create.
+      // Bitcoin's legacy txid excludes witness data, so we can build a
+      // skeleton with empty witnesses and get the same txid as the real tx.
+      let total_value =
+        coinbase1.output[0].value.to_sat() + coinbase2.output[0].value.to_sat();
+
+      let skeleton_tx = Transaction {
+        version: Version(2),
+        lock_time: LockTime::ZERO,
+        input: vec![
+          TxIn {
+            previous_output: OutPoint::new(coinbase1_txid, 0),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
+          },
+          TxIn {
+            previous_output: OutPoint::new(coinbase2_txid, 0),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
+          },
+        ],
+        output: vec![TxOut {
+          value: Amount::from_sat(total_value),
+          script_pubkey: ScriptBuf::new_p2wpkh(&WPubkeyHash::all_zeros()),
+        }],
+      };
+
+      let precomputed_txid = skeleton_tx.compute_txid();
+
+      // The child inscription (index 0) claims the parent inscription
+      // (index 1, same transaction) as its parent — a forward reference.
+      let forward_parent_id = InscriptionId {
+        txid: precomputed_txid,
+        index: 1,
+      };
+
+      let child_witness = Inscription {
+        content_type: Some("text/plain".into()),
+        body: Some("child".into()),
+        parents: vec![forward_parent_id.value()],
+        ..default()
+      }
+      .to_witness();
+
+      let parent_witness = inscription("text/plain", "parent").to_witness();
+
+      let txid = context.core.broadcast_tx(TransactionTemplate {
+        inputs: &[(1, 0, 0, child_witness), (2, 0, 0, parent_witness)],
+        ..default()
+      });
+
+      // Verify the pre-computed txid matches
+      assert_eq!(txid, precomputed_txid);
+
+      context.mine_blocks(1);
+
+      let child_inscription_id = InscriptionId { txid, index: 0 };
+
+      // With the fix, the forward reference is silently skipped rather
+      // than panicking. The child should have no parents.
+      assert!(
+        context
+          .index
+          .get_parents_by_inscription_id(child_inscription_id)
+          .is_empty()
+      );
+    }
+  }
 }

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -508,22 +508,23 @@ impl InscriptionUpdater<'_, '_> {
           self.sat_to_sequence_number.insert(&n, &sequence_number)?;
         }
 
-        let parent_sequence_numbers = parents
-          .iter()
-          .map(|parent| {
-            let parent_sequence_number = self
-              .id_to_sequence_number
-              .get(&parent.store())?
-              .unwrap()
-              .value();
+        let mut parent_inscription_ids = Vec::new();
+        let mut parent_sequence_numbers = Vec::new();
 
-            self
-              .sequence_number_to_children
-              .insert(parent_sequence_number, sequence_number)?;
+        for parent in parents.iter() {
+          let Some(entry) = self.id_to_sequence_number.get(&parent.store())? else {
+            continue;
+          };
 
-            Ok(parent_sequence_number)
-          })
-          .collect::<Result<Vec<u32>>>()?;
+          let parent_sequence_number = entry.value();
+
+          self
+            .sequence_number_to_children
+            .insert(parent_sequence_number, sequence_number)?;
+
+          parent_inscription_ids.push(*parent);
+          parent_sequence_numbers.push(parent_sequence_number);
+        }
 
         if let Some(ref sender) = index.event_sender {
           sender.blocking_send(Event::InscriptionCreated {
@@ -531,7 +532,7 @@ impl InscriptionUpdater<'_, '_> {
             charms,
             inscription_id,
             location: (!unbound).then_some(new_satpoint),
-            parent_inscription_ids: parents.clone(),
+            parent_inscription_ids: parent_inscription_ids.clone(),
             sequence_number,
           })?;
         }


### PR DESCRIPTION
When an inscription in a transaction references another inscription from the same transaction (at a higher input index) as its parent, the indexer would panic with `.unwrap()` on `None` because the parent hadn't been indexed yet at the time the child was processed.

This patch ports the fix from upstream ordinals/ord#4502 ("Filter invalid parents"): replace the `.unwrap()` panic with a `let Some(...) else { continue }` guard that silently skips unresolvable parent references. Only valid (already-indexed) parents are recorded in the child's entry and emitted in the InscriptionCreated event.

Also adds a regression test `same_tx_forward_parent_reference_does_not_panic` that constructs exactly this scenario and asserts the child has no parents (forward ref skipped gracefully).